### PR TITLE
Update deploy-office-online-server recommend plain OS

### DIFF
--- a/OfficeOnlineServer/deploy-office-online-server.md
+++ b/OfficeOnlineServer/deploy-office-online-server.md
@@ -40,7 +40,7 @@ Office Online Server is the next version of Office Web Apps Server. Deploying Of
 
 Perform these procedures on all servers that will run Office Online Server. This server must be Windows Server 2012 R2 or Windows Server 2016. (Note that Windows Server 2016 requires Office Online Server April 2017 or later.)
 
-Office Online Server was designed and tested for server operating systems configured with default settings.  It is recommended to avoid deploying Office Online Server to a modified operating system.
+Office Online Server was designed and tested for server operating systems configured with default settings.  If you need to deploy with non-default settings, it is recommended to begin installation and setup with the default settings.  Once the system is verified as working, then incrementally add and test Group Policies, security settings and other modifications.
     
     
 

--- a/OfficeOnlineServer/deploy-office-online-server.md
+++ b/OfficeOnlineServer/deploy-office-online-server.md
@@ -39,7 +39,8 @@ Office Online Server is the next version of Office Web Apps Server. Deploying Of
 <a name="prerequisites"> </a>
 
 Perform these procedures on all servers that will run Office Online Server. This server must be Windows Server 2012 R2 or Windows Server 2016. (Note that Windows Server 2016 requires Office Online Server April 2017 or later.)
-  
+
+Office Online Server was designed and tested for server operating systems configured with default settings.  It is recommended to avoid deploying Office Online Server to a modified operating system.
     
     
 


### PR DESCRIPTION
MS Support gets many requests for Office Online Server (OOS) new installs that do not function.  A key reason for failure is deploying to a heavily modified OS.  The resolutions is always to deploy to a unmodified OS then make modifications after OOS is working, this is due to the complex and undocumented OOS requirements.