### PR TITLE
Update office-online-server.md

### DIFF
--- a/OfficeOnlineServer/office-online-server.md
+++ b/OfficeOnlineServer/office-online-server.md
@@ -41,26 +41,16 @@ ms.assetid: e75c9827-f5ce-4099-a08c-b42fde72ea98
 | [Apply software updates to Office Online Server](apply-software-updates-to-office-online-server.md) <br/> |Explains how to apply software updates to your Office Online Server farm.  <br/> |
 | [Office Online Server release schedule](office-online-server-release-schedule.md) <br/> |Explains the release schedule for new Office Online Server builds, support dates, and upgrade requirements.  <br/> |
    
-
 Office Online Server can be downloaded from the  [Volume Licensing Service Center (VLSC)](https://go.microsoft.com/fwlink/p/?LinkId=256561). Office Online Server is a component of Office; therefore, it will be shown under each of the Office product pages including Office Standard 2016, Office Professional Plus 2016, and Office 2016 for Mac Standard. 
 
 For customers whose licenses qualfiy for OOS, but cannot obtain it through the VLSC, the following actions are possible: 
 
-- VL Open customers can contact their [Support Center](https://www.microsoft.com/Licensing/servicecenter/Help/Contact.aspx).
-- Customers who purchased O365 online from Microsoft can submit a request from their Office 365 admin center or [contact support](https://support.office.com/en-us/article/Contact-support-for-business-products-Admin-Help-32a17ca7-6fa0-4870-8a8d-e25ba4ccfd4b?CorrelationId=25670613-9263-4c87-8254-7c4563a1e0ac&ui=en-US&rs=en-US&ad=US&ocmsassetID=HA103836042).
-  
-    
-    
-
+VL Open customers who have licenses which qualify for OOS but cannot obtain it through the VLSC can contact their [Support Center](https://www.microsoft.com/Licensing/servicecenter/Help/Contact.aspx).
 
 ## Office Online Server version compatibility list
 <a name="version"> </a>
 
 The following table shows the compatibility between Office Web Apps Server and Office Online Server with SharePoint Server, Exchange Server, and Skype for Business Server.
-  
-    
-    
-
 
 |**Product**|**Office Web Apps Server**|**Office Online Server**|
 |:-----|:-----|:-----|


### PR DESCRIPTION
Update for #3. Going through O365 Support is not an option. Customers must contact the licensing support center as noted for those with "VL Open". Per O365 Support (Case #11996225 if you need it), you must have a volume license agreement and having O365-only licenses is not sufficient:

"Upon further research it seems you will need to have a volume license account/agreement. Once you have this, you will be able to access VLSC."